### PR TITLE
Request/Response logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,14 @@
     "express": "4.13.x",
     "express-fileupload": "0.0.5",
     "express-flash": "0.0.2",
+    "express-winston": "^2.1.2",
     "forever": "0.15.x",
     "graceful-fs": "^4.1.10",
     "moment": "^2.17.1",
     "nodemailer": "^2.7.0",
     "path": "^0.12.7",
-    "request": "^2.75.0"
+    "request": "^2.75.0",
+    "winston": "^2.3.0"
   },
   "devDependencies": {
     "eslint": "^3.7.1",

--- a/server.js
+++ b/server.js
@@ -19,6 +19,8 @@ const request = require('request');
 const utils = require('./etc/utils.js');
 const flash = require('express-flash');
 const nodemailer = require('nodemailer');
+const winston = require('winston');
+const expressWinston = require('express-winston');
 
 // require('request-debug')(request); // for debugging of outbound requests
 
@@ -48,7 +50,13 @@ app.use(session({
 	secure: true, // cookie can only be used over HTTPS
 	ephemeral: true // Deletes cookie when browser closes.
 }));
-
+app.use(expressWinston.logger({
+  transports: [
+    new winston.transports.Console()
+  ],
+  meta: false, // don't log metadata about requests (produces very messy logs if true)
+  expressFormat: true, // Use the default Express/morgan request formatting.
+}));
 app.use(function(req, res, next){ //mainly for the inital load, setting initial values for the session
 	if(!req.session.roles) {
 		req.session.roles = {


### PR DESCRIPTION
Currently, we don't have any logging on the `desktop-frontend`.

Adding request/response logging with `express-winston`.

Assuming this PR is merged, we can add this type of logging with the other express/node services.