### PR TITLE
Fixed left alignment for three-columns on homepage

### DIFF
--- a/public/less/partials/home.less
+++ b/public/less/partials/home.less
@@ -41,7 +41,8 @@
 
 }
 
-#involvment {
+#involvement {
+    
 }
 
 #main-center {

--- a/public/less/partials/home.less
+++ b/public/less/partials/home.less
@@ -38,12 +38,8 @@
     flex: 1; /* additionally, equal width */
     padding: 30px 30px ;
     margin-top: 25px;
-
 }
 
-#involvement {
-    
-}
 
 #main-center {
     flex: 1; /* additionally, equal width */
@@ -55,14 +51,15 @@
     flex: 1; /* additionally, equal width */
     padding: 30px 30px ;
     margin-top: 25px;
-
 }
 
+#involvement>#main-left,#involvement>#main-center,#involvement>#main-right {
+  padding: 30px 30px 60px 0px;
+}
 
 #events-container {
       //  height: 40vh;
         overflow: hidden;
-
 }
 
 #events-title {

--- a/public/less/partials/home.less
+++ b/public/less/partials/home.less
@@ -54,7 +54,7 @@
 }
 
 #involvement>#main-left,#involvement>#main-center,#involvement>#main-right {
-  padding: 30px 30px 60px 0px;
+  padding: 30px 30px 30px 0px;
 }
 
 #events-container {

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -28,7 +28,7 @@ this license in a file with the distribution.
       <p>Held at the beginning of Spring and Fall semesters, this is a great opportunity to learn more about ACM and its various Special Interest Groups (SIGs).</p>
       <p></p>
     </div>
-    <div id="invovlement" class="row">
+    <div id="involvement" class="row">
       <div id="main-left" class="small-12 medium-12 large-4 columns">
         <h3>Join ACM</h3>
         <p>As an ACM member you get access to our compute cluster, free black and white printing, Beats by ACM, Caffeine, and many other member perks.</p><a href="/join">


### PR DESCRIPTION
Corrected typo in main html, added rule for id #involvement to match the left margin.

Total margin remains unchanged (30px, 30px -> 30px, 60px, 30px, 0px). 
