### PR TITLE
Intranet Card Refactor

### DIFF
--- a/public/less/main.less
+++ b/public/less/main.less
@@ -50,6 +50,7 @@
 @import "partials/conference.less";
 @import "partials/join.less";
 @import "partials/memes.less";
+@import "partials/intranet.less";
 
 @import "elements/form.less";
 @import "elements/button.less";

--- a/public/less/partials/intranet.less
+++ b/public/less/partials/intranet.less
@@ -1,0 +1,21 @@
+.intranet-card {
+    margin-top: 15px;
+    margin-right: 10px;
+    margin-bottom: auto;
+    width: 32%;
+    max-height: 500px;
+    border-style: none;
+}
+
+@media only screen and (max-width: 768px) {
+    .intranet-card {
+        width: 100%;
+    }
+}
+
+.intranet-card-container {
+    padding-top: 20px;
+    padding-bottom: 50px;
+    display:flex;
+    flex-wrap:wrap;
+}

--- a/public/less/partials/memes.less
+++ b/public/less/partials/memes.less
@@ -11,10 +11,6 @@
     padding-right: 10px;
 }
 
-.meme-card-row {
-    display: flex;
-}
-
 .meme-card {
     margin-top: 5px;
     margin-right: 10px;

--- a/views/intranet.ejs
+++ b/views/intranet.ejs
@@ -35,99 +35,89 @@ this license in a file with the distribution.
         <% } %>
       </div>
     </div>
-    <% if (session.roles.isAdmin || session.roles.isTop4) { %>
-      <div id="links-top" class="row">
-        <div id="main-left" class="small-12 medium-12 large-4 columns">
+    <div class="intranet-card-container">
+      <% if (session.roles.isAdmin || session.roles.isTop4) { %>
+        <div class="intranet-card card">
             <h3>Caffeine</h3>
             <p>Caffeine vending machine placeholder text</p>
             <a href="/caffeine"><button class="button">Manage</button></a>
         </div>
-        <div id="main-center" class="small-12 medium-12 large-4 columns">
+        <div class="intranet-card card">
           <h3>User Manager</h3>
           <p>View and maintain current and pending ACM users</p>
           <a href="intranet/users"><button class="button">Manage</button></a>
         </div>
-      </div>
-    <% } %>
+      <% } %>
 
-    <% if (session.roles.isCorporate) { %>
-      <div id="links-top" class="row">
-        <div id="main-left" class="small-12 medium-12 large-4 columns">
+      <% if (session.roles.isCorporate) { %>
+        <div class="intranet-card card">
           <h3>Corporate Service Manager</h3>
           <p>Maintain resumes and job posts</p>
           <a href="/corporate/manage"><button class="button">Manage</button></a>
         </div>
-        <div id="main-center" class="small-12 medium-12 large-4 columns">
+        <div class="intranet-card card">
           <h3>Account Manager</h3>
           <p>Maintain all recruiter accounts</p>
           <a href="corporate/accounts"><button class="button">Manage</button></a>
         </div>
-        <div id="main-right" class="small-12 medium-12 large-4 columns">
+        <div class="intranet-card card">
           <h3>Resume Database</h3>
           <p>View and filter student resumes</p>
           <a href="corporate/resumes"><button class="button">View Resumes</button></a>
         </div>
-      </div>
-    <% } %>    
-    <% if (session.roles.isRecruiter && session.recruiter.is_sponsor) { %>
-      <div id="links-top" class="row">
-        <div id="main-left" class="small-12 medium-12 large-4 columns">
+      <% } %>    
+      <% if (session.roles.isRecruiter && session.recruiter.is_sponsor) { %>
+        <div class="intranet-card card">
           <h3>Resume Database</h3>
           <p>View and filter student resumes</p><a href="corporate/resumes">
           <button class="button">View Resumes</button></a>
         </div>
 
-        <div id="main-center" class="small-12 medium-12 large-4 columns">
+        <div class="intranet-card card">
           <h3>Create Job Listing</h3>
           <p>Post a job listing for students</p><a href="sponsors/jobs">
           <button class="button">Post Job Listing</button></a>
         </div>
 
-        <div id="main-right" class="small-12 medium-12 large-4 columns">
+        <div class="intranet-card card">
           <h3>Beats by ACM</h3>
           <p>Control the Beats music system.</p><a href="https://www-s.acm.illinois.edu/beats/1104/">
           <button class="button">Go</button></a>
         </div>
-      </div>
-    <% } else if (session.roles.isRecruiter) { %>
-      <div id="links-top" class="row">
-        <div id="main-left" class="small-12 medium-12 large-12 columns">
+      <% } else if (session.roles.isRecruiter) { %>
+        <div class="intranet-card card">
           <h3>Register for the career fair!</h3>
           <p>Click to register for the career fair</p><a href="/corporate/careerweek/2017">
           <button class="button">Register</button></a>
         </div>
-      </div>
-    <% } %>
+      <% } %>
 
 
-    <% if (session.roles.isStudent) { %>
-      <div id="links-top" class="row">
-        <div id="main-left" class="small-12 medium-12 large-4 columns">
+      <% if (session.roles.isStudent) { %>
+        <div class="intranet-card card">
           <h3>Quote Database</h3>
           <p>Memorable quotes from ACM members past and present</p><a href="/intranet/quotes">
           <button class="button">View Quotes</button></a>
         </div>
-        <div id="main-center" class="small-12 medium-12 large-4 columns">
+        <div class="intranet-card card">
           <h3>Meme Service</h3>
           <p>5/7 memes from ACM memebers</p><a href="/memes">
           <button class="button">Me 2 thanks</button></a>
         </div>
-        <div id="main-right" class="small-12 medium-12 large-4 columns">
+        <div class="intranet-card card">
           <h3>Beats by ACM</h3>
           <p>Control the Beats music system.</p><a href="https://www-s.acm.illinois.edu/beats/1104/">
           <button class="button">Go</button></a>
         </div>
-      </div>
 
-      <div id="links-top" class="row">
-        <div id="main-left" class="small-12 medium-12 large-4 columns">
+        <div class="intranet-card card">
           <h3>Job Database</h3>
           <p>View and filter jobs on campus</p>
           <a href="/jobs">
             <button class="button">View jobs</button>
           </a>
         </div>
-      <div id="main-center" class="small-12 medium-12 large-4 columns">
+        <div class="intranet-card card">
           <h3>Credits</h3>
           <p>View and refill your ACM credits balance</p>
           <a href="/credits">
@@ -139,8 +129,8 @@ this license in a file with the distribution.
             </a>
           <% } %>
         </div>
-      </div>
-    <% } %>
+      <% } %>
+    </div>
   </div>
 
   <div id="events-container" class="small-12 medium-12 large-3 columns">


### PR DESCRIPTION
Better, automatic intranet card layout. Addresses #71 

Lays out cards to be visually similar to old design:
<img width="832" alt="screen shot 2017-02-21 at 1 38 04 pm" src="https://cloud.githubusercontent.com/assets/706257/23181584/1d69dc26-f83b-11e6-933b-6c73769c1cd2.png">

Handles responsiveness well:
<img width="344" alt="screen shot 2017-02-21 at 1 38 23 pm" src="https://cloud.githubusercontent.com/assets/706257/23181578/18f9476c-f83b-11e6-98df-f2ab39fd8bad.png">
