### PR TITLE
Landing page for new unpaid users

### DIFF
--- a/app/controllers/credits.js
+++ b/app/controllers/credits.js
@@ -13,6 +13,7 @@ const GROOT_ACCESS_TOKEN = process.env.GROOT_ACCESS_TOKEN || "TEMP_STRING";
 const STRIPE_PUBLISHABLE_KEY = process.env.STRIPE_PUBLISHABLE_KEY || "TEMP_STRING";
 const request = require('request');
 const moment = require('moment');
+const utils = require('../../etc/utils.js');
 
 function makeUserPaid(req, res, nextSteps) {
   request({
@@ -26,7 +27,9 @@ function makeUserPaid(req, res, nextSteps) {
       req.flash('error', "Unable to make user a paid user. Talk to someone in ACM Admin.");
       return req.redirect("/");
     }
-    nextSteps(req, res);
+    utils.getUserData(req, res, function(req, res) {
+      nextSteps(req, res);
+    });
   });
 }
 
@@ -185,14 +188,21 @@ module.exports = function(app){
     });
   });
   app.get('/credits/purchaseMembership', function(req, res) {
-    // TODO: Redirect if not a 'pre-member'
+    // Redirect if not a 'pre-member'
+    if(req.session.student.isPaid) {
+      return res.redirect('/intranet');
+    }
+
     res.render('credits/credits_purchase_membership', {
       authenticated: true,
       stripePublishableKey: STRIPE_PUBLISHABLE_KEY
     });
   });
   app.post('/credits/purchaseMembership', function(req, res) {
-    // TODO: Redirect if not a 'pre-member'
+    // Redirect if not a 'pre-member'
+    if(req.session.student.isPaid) {
+      return res.redirect('/intranet');
+    }
 
     // Sanity checks
     if(!req.body.stripeToken) {

--- a/app/controllers/groups.js
+++ b/app/controllers/groups.js
@@ -14,30 +14,6 @@ const request = require('request');
 const utils = require('../../etc/utils.js');
 
 module.exports = function(app) {
-  app.get('/join', function(req, res) {
-    if(utils.isAuthenticated(req)) {
-      return res.redirect('/intranet');
-    }
-
-    request({
-      url: `${SERVICES_URL}/groups/sigs`,
-      headers: {
-        "Authorization": GROOT_ACCESS_TOKEN
-      },
-      method: "GET",
-    }, function(err, response, body) {
-      if (err || !response || response.statusCode != 200) {
-        return res.status(500).send(err);
-      }
-      res.render('users/join', {
-        authenticated: false,
-        sigs: JSON.parse(body),
-        messages: req.flash('success'),
-        errors: req.flash('error')
-      });
-    });
-  });
-
   app.get('/sigs', function(req, res) {
     request({
       url: `${SERVICES_URL}/groups/sigs`,

--- a/app/controllers/users.js
+++ b/app/controllers/users.js
@@ -93,6 +93,30 @@ module.exports = function(app) {
     });
   });
 
+  app.get('/join', function(req, res) {
+    if(utils.isAuthenticated(req)) {
+      return res.redirect('/intranet');
+    }
+
+    request({
+      url: `${SERVICES_URL}/groups/sigs`,
+      headers: {
+        "Authorization": GROOT_ACCESS_TOKEN
+      },
+      method: "GET",
+    }, function(err, response, body) {
+      if (err || !response || response.statusCode != 200) {
+        return res.status(500).send(err);
+      }
+      res.render('users/join', {
+        authenticated: false,
+        sigs: JSON.parse(body),
+        messages: req.flash('success'),
+        errors: req.flash('error')
+      });
+    });
+  });
+
   app.post('/join', function(req, res) {
     request({
       url: `${SERVICES_URL}/users`,
@@ -109,6 +133,14 @@ module.exports = function(app) {
         req.flash('success', body.message);
       }
       res.redirect('/join');
+    });
+  });
+
+  app.get('/unpaid', function(req, res) {
+    return res.render('users/unpaid', {
+      authenticated: utils.isAuthenticated(req),
+      messages: req.flash('success'),
+      errors: req.flash('error')
     });
   });
 
@@ -130,7 +162,8 @@ module.exports = function(app) {
           first_name: body.data.first_name,
           last_name: body.data.last_name,
           token: body.data.token,
-          netid: body.data.netid
+          netid: body.data.netid,
+          isPaid: body.data.is_member
         };
         req.session.username = req.session.student.first_name;
         req.session.roles.isStudent = true;

--- a/app/views/credits/credits_purchase_membership.ejs
+++ b/app/views/credits/credits_purchase_membership.ejs
@@ -11,7 +11,7 @@ this license in a file with the distribution.
 <%- include('../_partials/header') -%>
 
 <div id="meme-upload-container">
-  <div class="row col-centered small-12 medium-4 large-4">
+  <div class="row col-centered small-12 medium-6 large-4">
     <h3>Purchase ACM Membership</h3>
     <h5>Invoice</h5>
     <table class="dynatable-container" style="margin-bottom: 1em;">

--- a/app/views/users/unpaid.ejs
+++ b/app/views/users/unpaid.ejs
@@ -1,0 +1,25 @@
+<!--
+Copyright © 2017, ACM@UIUC
+
+This file is part of the Groot Project.
+
+The Groot Project is open source software, released under the University of
+Illinois/NCSA Open Source License.  You should have received a copy of
+this license in a file with the distribution.
+-->
+
+<%- include('../_partials/header') -%>
+
+<div id="home-container" class="row">
+  <div id="main-container" class="small-12 medium-9 large-9 columns">
+    <%- include('../_partials/flash') -%>
+    <h2>Unpaid Member</h2>
+    <p>The ACM intranet is currently only available to members who have paid the membership fee. For more information about ACM, check out our <a href="/about">About</a> page.</p>
+    <a class="button" href='/credits/purchaseMembership'>Purchase ACM Membership</a>
+  </div>
+</div>
+<div class="footer_padding">
+</div>
+<%- include('../_partials/footer') -%>
+
+

--- a/etc/utils.js
+++ b/etc/utils.js
@@ -75,6 +75,7 @@ exports.getUserData = function(req, res, nextSteps){
     if(body && body[0] != undefined) {
       req.session.student.firstName = body[0].first_name;
       req.session.student.lastName = body[0].last_name;
+      req.session.student.isPaid = body[0].is_member;
       req.session.username = req.session.student.firstName;
     }
     nextSteps(req, res);

--- a/server.js
+++ b/server.js
@@ -130,6 +130,10 @@ app.get('/intranet', function(req, res) {
   if(!utils.isAuthenticated(req)) {
     return res.redirect('/login');
   }
+
+  if(!req.session.student.isPaid) {
+    return res.redirect('/unpaid');
+  }
   
   if (req.session.roles.isRecruiter) {
     return res.render('desktop/intranet', {


### PR DESCRIPTION
If a user is unpaid, they should not have access to the intranet.

This PR creates a simple landing page for unpaid users that directs them to the page for paying the ACM membership fee.

This should not be merged until we are confident that the membership payment flow is working (i.e. we still need the AD script)