### PR TITLE
Fix merch item footer

### DIFF
--- a/app/views/merch/edit.ejs
+++ b/app/views/merch/edit.ejs
@@ -24,6 +24,7 @@ this license in a file with the distribution.
         <label for="name" class="field-albe">Item Name</label>
         <div class="field">
           <input id="name" type="text" name="name" maxlength="16" value="<%= item.name %>" />
+        </div>
       </div>
       <div class="field-group required">
           <label for="price" class="field-label">Price</label>


### PR DESCRIPTION
Forgot closing `</div>`, so it messed up the html and erroneously caused the footer to remain inside a div

Addresses https://github.com/acm-uiuc/groot-desktop-frontend/issues/107

Screenshot
<img width="1438" alt="screenshot 2017-09-04 23 21 03" src="https://user-images.githubusercontent.com/3608224/30045119-c6f0295a-91c7-11e7-9999-b4e844c35b4f.png">
