### PR TITLE
Allow all authenticated users to view merch and see items

### DIFF
--- a/app/controllers/merch.js
+++ b/app/controllers/merch.js
@@ -15,10 +15,8 @@ const utils = require('../../etc/utils.js');
 
 module.exports = function(app) {
   app.get('/intranet/merch/items', function(req, res) {
-    if(!req.session.roles.isAdmin && !req.session.roles.isTop4 && !req.session.roles.isCorporate) {
-      res.redirect('/intranet');
-    }
-
+    // Let any user view items that are vended, but restrict them from modifying the contents of the items
+    
     request({
       url: `${SERVICES_URL}/merch/locations`,
       method: "GET",
@@ -29,6 +27,7 @@ module.exports = function(app) {
     }, function(error, response, body) {
       res.render('merch/index.ejs', {
         authenticated: utils.isAuthenticated(req),
+        roles: req.session.roles,
         locations: body.data,
         success: req.flash('success'),
         errors: req.flash('error')

--- a/app/views/desktop/intranet.ejs
+++ b/app/views/desktop/intranet.ejs
@@ -35,13 +35,17 @@ this license in a file with the distribution.
         <% } %>
       </div>
     </div>
-    <div class="intranet-card-container">
-      <% if (session.roles.isAdmin || session.roles.isTop4) { %>
-        <div class="intranet-card card">
-            <h3>Merch</h3>
+    <div class="intranet-card-container">      
+      <div class="intranet-card card">
+          <h3>Merch</h3>
+          <% if (session.roles.isAdmin || session.roles.isTop4) { %>
             <p>View and maintain available items</p>
-            <a href="/intranet/merch/items"><button class="button">Manage</button></a>
-        </div>
+          <% } else { %>
+            <p>View available items to vend</p>
+          <% } %>
+          <a href="/intranet/merch/items"><button class="button">View items</button></a>
+      </div>
+      <% if (session.roles.isAdmin || session.roles.isTop4) { %>
         <div class="intranet-card card">
           <h3>User Manager</h3>
           <p>View and maintain current and pending ACM users</p>

--- a/app/views/merch/index.ejs
+++ b/app/views/merch/index.ejs
@@ -29,21 +29,25 @@ this license in a file with the distribution.
         </a>
         <% if (locations[i].item == null) { %>
             <h5><%= locations[i].location %>: Unassigned</h5>
-            <a href="items/<%= locations[i].location %>/new">
-                <i class="fa fa-plus" aria-hidden="true"></i>
-                Assign to item
-            </a>
+            <% if (roles.isAdmin || roles.isTop4) { %>
+                <a href="items/<%= locations[i].location %>/new">
+                    <i class="fa fa-plus" aria-hidden="true"></i>
+                    Assign to item
+                </a>
+            <% } %>
         <% } else { %>
             <h5><%= locations[i].location %>: <%= locations[i].quantity %> of <%= locations[i].item.name %></h5>
-            <a href="items/<%= locations[i].item.id %>/<%= locations[i].location %>/edit">
-                <i class="fa fa-pencil" aria-hidden="true"></i>
-                Edit
-            </a>
-            <br/>
-            <a href="#" onclick="clearItem('<%= locations[i].location %>');">
-                <i class="fa fa-trash" aria-hidden="true"></i>
-                Delete
-            </a>
+            <% if (roles.isAdmin || roles.isTop4) { %>
+                <a href="items/<%= locations[i].item.id %>/<%= locations[i].location %>/edit">
+                    <i class="fa fa-pencil" aria-hidden="true"></i>
+                    Edit
+                </a>
+                <br/>
+                <a href="#" onclick="clearItem('<%= locations[i].location %>');">
+                    <i class="fa fa-trash" aria-hidden="true"></i>
+                    Delete
+                </a>
+            <% } %>
         <% } %>
         </div>
     <% } %>


### PR DESCRIPTION
- Wrap edit and delete items on the merch view in auth-checking if statements

New default intranet view for a student with no access to anything:

![screenshot 2017-09-06 22 38 05](https://user-images.githubusercontent.com/3608224/30144973-106a091a-9354-11e7-9ea5-d183d58eb5e6.png)

What they can see on `intranet/merch`:
![screenshot 2017-09-06 22 38 45](https://user-images.githubusercontent.com/3608224/30144989-2951cdf0-9354-11e7-8841-b576870f24aa.png)

@rauhul
